### PR TITLE
fix: resolve thread safety issues in simulation engine

### DIFF
--- a/include/core/Environment.hpp
+++ b/include/core/Environment.hpp
@@ -11,45 +11,139 @@
 #include "Organism.hpp"
 #include "index/ISpatialIndex.hpp"
 
+/**
+ * @brief The simulation world that manages organisms, food, and spatial queries.
+ *
+ * Environment owns all simulation objects, delegates spatial lookups to an
+ * ISpatialIndex implementation, and drives the interact-react-move lifecycle
+ * each iteration. The interaction phase runs single-threaded because it mutates
+ * shared state (food eaten flags, organism lifespans). The reaction phase can
+ * be parallelized since each organism only writes to its own movement fields.
+ */
 class Environment {
 public:
+    /**
+     * @brief Construct an environment with the given dimensions and spatial index type.
+     * @param width  The horizontal extent of the simulation area.
+     * @param height The vertical extent of the simulation area.
+     * @param type   Spatial index implementation: "default" or "optimized".
+     * @param numThreads Number of threads for the parallelizable reaction phase.
+     * @throws std::invalid_argument If type is not "default" or "optimized".
+     */
     Environment(int width, int height, std::string type = "default", int numThreads = 1);
+
+    /** @brief Get the horizontal extent of the environment. */
     int getWidth() const { return width; }
+
+    /** @brief Get the vertical extent of the environment. */
     int getHeight() const { return height; }
 
+    /**
+     * @brief Add an organism to the environment at the specified coordinates.
+     * @param organism Shared pointer to the organism.
+     * @param x Horizontal position.
+     * @param y Vertical position.
+     * @throws std::out_of_range If (x, y) is outside the environment bounds.
+     */
     void add(const std::shared_ptr<Organism>& organism, float x, float y);
+
+    /**
+     * @brief Add a food item to the environment at the specified coordinates.
+     * @param food Shared pointer to the food.
+     * @param x Horizontal position.
+     * @param y Vertical position.
+     * @throws std::out_of_range If (x, y) is outside the environment bounds.
+     */
     void add(const std::shared_ptr<Food>& food, float x, float y);
 
+    /**
+     * @brief Remove an organism from the environment and spatial index.
+     * @param organism Shared pointer to the organism to remove.
+     * @throws std::runtime_error If the organism is not found.
+     */
     void remove(const std::shared_ptr<Organism>& organism);
+
+    /**
+     * @brief Remove a food item from the environment and spatial index.
+     * @param food Shared pointer to the food to remove.
+     * @throws std::runtime_error If the food is not found.
+     */
     void remove(const std::shared_ptr<Food>& food);
 
+    /** @brief Clear all objects, dead organisms, and counters from the environment. */
     void reset();
 
-    void simulateIteration(int,
+    /**
+     * @brief Run the simulation for a given number of iterations.
+     * @param iterations Number of iterations to simulate.
+     * @param on_each_iteration Optional callback invoked after each iteration.
+     *
+     * Each iteration proceeds in order: interactions (single-threaded),
+     * reactions (optionally multi-threaded), then post-iteration (life
+     * consumption + movement). Stops early if no organisms or food remain.
+     */
+    void simulateIteration(int iterations,
                            std::function<void(const Environment&)> on_each_iteration = nullptr);
 
+    /** @brief Get all living organisms currently in the environment. */
     std::vector<std::shared_ptr<Organism>> getAllOrganisms() const;
+
+    /** @brief Get all food items currently in the environment. */
     std::vector<std::shared_ptr<Food>> getAllFoods() const;
+
+    /** @brief Get all environment objects (organisms and food). */
     std::vector<std::shared_ptr<EnvironmentObject>> getAllObjects() const;
+
+    /** @brief Get organisms that died during the simulation run. */
     std::vector<std::shared_ptr<Organism>> getDeadOrganisms() const;
+
+    /** @brief Get the total number of food items consumed across all iterations. */
     unsigned long getFoodConsumptionInIteration() const;
 
 private:
     int width, height;
-    std::string type;
+    std::string type;  ///< Spatial index type identifier ("default" or "optimized")
     std::unique_ptr<ISpatialIndex<boost::uuids::uuid>> spatialIndex;
+    /// Maps object UUIDs to their shared pointers for O(1) lookup
     std::unordered_map<boost::uuids::uuid, std::shared_ptr<EnvironmentObject>> objectsMapper;
 
-    std::vector<std::shared_ptr<Organism>> deadOrganisms;
-    unsigned long foodConsumption;
+    std::vector<std::shared_ptr<Organism>> deadOrganisms;  ///< Accumulated dead organisms
+    unsigned long foodConsumption;                         ///< Running food consumption counter
 
-    int numThreads = 1;
+    int numThreads = 1;  ///< Thread count for the parallelizable reaction phase
 
+    /**
+     * @brief Validate that coordinates fall within environment bounds.
+     * @param x Horizontal coordinate.
+     * @param y Vertical coordinate.
+     * @throws std::out_of_range If coordinates are outside [0, width] x [0, height].
+     */
     void checkBounds(float x, float y) const;
+
+    /** @brief Sync organism positions into the spatial index, clamping to bounds. */
     void updatePositionsInSpatialIndex();
+
+    /**
+     * @brief Run the interaction phase: organisms eat food and fight.
+     *
+     * Runs single-threaded because interactions mutate shared state (food
+     * eaten flags, other organisms' lifespans) which would cause data races.
+     */
     void handleInteractions();
+
+    /**
+     * @brief Run the reaction phase: organisms decide movement direction.
+     *
+     * Safe to parallelize because each organism only writes to its own
+     * movement vector and reactionCounter. Uses numThreads worker threads
+     * when numThreads > 1.
+     */
     void handleReactions();
+
+    /** @brief Run post-iteration: deduct life consumption, move organisms, update spatial index. */
     void postIteration();
+
+    /** @brief Remove dead organisms and eaten food from the active object map. */
     void cleanUp();
 };
 

--- a/include/core/Environment.hpp
+++ b/include/core/Environment.hpp
@@ -51,7 +51,6 @@ private:
     void handleReactions();
     void postIteration();
     void cleanUp();
-    void removeDeadOrganisms();
 };
 
 #endif

--- a/include/core/Food.hpp
+++ b/include/core/Food.hpp
@@ -1,6 +1,8 @@
 #ifndef FOOD_HPP
 #define FOOD_HPP
 
+#include <atomic>
+
 #include "EnvironmentObject.hpp"
 
 enum class FoodState { FRESH, EATEN };
@@ -8,12 +10,12 @@ enum class FoodState { FRESH, EATEN };
 class Food : public EnvironmentObject {
 public:
     Food() : EnvironmentObject(0, 0) {}
-    bool canBeEaten() { return state == FoodState::FRESH; }
-    void eaten() { state = FoodState::EATEN; }
+    bool canBeEaten() const { return state.load(std::memory_order_acquire) == FoodState::FRESH; }
+    void eaten() { state.store(FoodState::EATEN, std::memory_order_release); }
     int getEnergy() const { return 500; }
 
 private:
-    FoodState state = FoodState::FRESH;
+    std::atomic<FoodState> state{FoodState::FRESH};
 };
 
 #endif

--- a/include/core/Food.hpp
+++ b/include/core/Food.hpp
@@ -5,16 +5,46 @@
 
 #include "EnvironmentObject.hpp"
 
+/**
+ * @brief Represents the lifecycle state of a Food object.
+ */
 enum class FoodState { FRESH, EATEN };
 
+/**
+ * @brief A consumable food item that organisms can eat to gain energy.
+ *
+ * Food objects exist in the environment and provide a fixed amount of energy
+ * when consumed. Once eaten, the food transitions to the EATEN state and will
+ * be cleaned up by the environment. Uses atomic state to allow safe concurrent
+ * reads during the parallelizable reaction phase.
+ */
 class Food : public EnvironmentObject {
 public:
+    /** @brief Construct a Food object at the origin with default energy (500). */
     Food() : EnvironmentObject(0, 0) {}
+
+    /**
+     * @brief Check whether this food is still available for consumption.
+     * @return true if the food has not yet been eaten.
+     */
     bool canBeEaten() const { return state.load(std::memory_order_acquire) == FoodState::FRESH; }
+
+    /**
+     * @brief Mark this food as eaten, transitioning it to the EATEN state.
+     *
+     * Uses release memory ordering so that the state change is visible to
+     * concurrent readers in the reaction phase.
+     */
     void eaten() { state.store(FoodState::EATEN, std::memory_order_release); }
+
+    /**
+     * @brief Get the energy value this food provides when consumed.
+     * @return Fixed energy value (500) added to the consuming organism's lifespan.
+     */
     int getEnergy() const { return 500; }
 
 private:
+    /// Atomic state ensures safe concurrent access from the parallel reaction phase.
     std::atomic<FoodState> state{FoodState::FRESH};
 };
 

--- a/include/core/Genes.hpp
+++ b/include/core/Genes.hpp
@@ -3,19 +3,51 @@
 
 #include <functional>
 
+/**
+ * @brief Encodes the genetic traits of an organism as a 4-byte DNA sequence.
+ *
+ * Each byte in the DNA array maps to a specific organism trait:
+ *   - dna[0]: speed
+ *   - dna[1]: size
+ *   - dna[2]: awareness
+ *   - dna[3]: reserved
+ *
+ * Mutation logic can be customized by providing a MutationFunction. If none
+ * is provided, the default adds a small random offset ([-3, +3]) to each byte.
+ */
 class Genes {
 public:
+    /// @brief Function type for custom mutation logic operating on the 4-byte DNA.
     using MutationFunction = std::function<void(char[4])>;
 
+    /**
+     * @brief Construct genes from a 4-byte DNA string using default mutation logic.
+     * @param dnaStr Pointer to a 4-byte character array representing the DNA.
+     */
     Genes(const char *dnaStr);
+
+    /**
+     * @brief Construct genes with optional custom mutation logic.
+     * @param dnaStr Pointer to a 4-byte character array representing the DNA.
+     * @param customMutationLogic Custom mutation function; if null, uses default.
+     */
     Genes(const char *dnaStr, MutationFunction customMutationLogic);
 
+    /// @brief Apply the mutation function to this gene's DNA in-place.
     void mutate();
+
+    /**
+     * @brief Access a specific DNA byte by index.
+     * @param index The DNA index (0-3).
+     * @return The raw byte value at the given index.
+     */
     char getDNA(int index) const;
 
 private:
-    char dna[4];
-    MutationFunction mutationLogic;
+    char dna[4];                    ///< The 4-byte DNA sequence
+    MutationFunction mutationLogic; ///< The mutation strategy applied during reproduction
+
+    /// @brief Default mutation: adds uniform random offset in [-3, +3] to each byte.
     static void defaultMutationLogic(char dna[4]);
 };
 

--- a/include/core/Organism.hpp
+++ b/include/core/Organism.hpp
@@ -9,45 +9,140 @@
 #include "EnvironmentObject.hpp"
 #include "Genes.hpp"
 
+/**
+ * @brief A living entity in the simulation that can move, eat, fight, and reproduce.
+ *
+ * Organisms have gene-derived attributes (speed, size, awareness) that determine
+ * their behavior and survival. Each iteration, organisms react to nearby objects
+ * (deciding movement direction) and interact with overlapping objects (eating food,
+ * killing smaller organisms). Reproduction creates a mutated offspring and halves
+ * the parent's lifespan.
+ */
 class Organism : public EnvironmentObject {
 public:
+    /**
+     * @brief Callable that computes per-iteration life consumption from organism attributes.
+     *
+     * When set, overrides the default quadratic cost formula. Allows Python or
+     * C++ callers to define custom energy expenditure rules.
+     */
     using LifeConsumptionCalculator = std::function<uint32_t(const Organism &)>;
 
+    /** @brief Construct a default organism with preset genes and 500 lifespan. */
     Organism();
+
+    /**
+     * @brief Construct an organism with the given genes.
+     * @param genes The genetic data determining speed, size, and awareness.
+     */
     Organism(const Genes &genes);
+
+    /**
+     * @brief Construct an organism with genes and a custom life consumption formula.
+     * @param genes The genetic data determining speed, size, and awareness.
+     * @param lifeConsumptionCalculator Custom function to compute per-tick life drain.
+     */
     Organism(const Genes &genes, LifeConsumptionCalculator lifeConsumptionCalculator);
 
-    // attributes
+    /** @brief Get movement speed derived from gene index 0 (DNA byte / 4.0). */
     float getSpeed() const;
+
+    /** @brief Get body size derived from gene index 1 (DNA byte / 4.0). */
     float getSize() const;
+
+    /** @brief Get awareness radius derived from gene index 2 (DNA byte / 4.0). */
     float getAwareness() const;
+
+    /**
+     * @brief Get per-iteration life consumption.
+     * @return Life consumed per tick; uses custom calculator if set, otherwise
+     *         a default quadratic formula based on speed, size, and awareness.
+     */
     float getLifeConsumption() const;
+
+    /** @brief Get the current remaining lifespan. */
     float getLifeSpan() const;
+
+    /**
+     * @brief Get the radius within which this organism can react to objects.
+     * @return Sum of size and awareness attributes.
+     */
     float getReactionRadius() const;
 
-    // status
+    /** @brief Mark this organism as dead (lifespan set to 0). */
     void killed();
+
+    /**
+     * @brief Check whether this organism is still alive.
+     * @return true if lifespan is greater than 0.
+     */
     bool isAlive() const;
+
+    /**
+     * @brief Check whether this organism has enough lifespan to reproduce.
+     * @return true if lifespan exceeds the reproduction threshold (1000).
+     */
     bool canReproduce() const;
 
     ~Organism() {};
 
-    // actions
+    /**
+     * @brief Decide movement direction based on nearby objects within reaction radius.
+     * @param reactableObjects Objects detected within the organism's reaction radius.
+     *
+     * Finds the nearest valid object and sets movement direction accordingly:
+     * flee from larger organisms, chase smaller organisms, move toward food.
+     * Only triggers once per iteration (guarded by reactionCounter).
+     * Safe to call in parallel -- only writes to this organism's own fields.
+     */
     void react(const std::vector<std::shared_ptr<EnvironmentObject>> &reactableObjects);
+
+    /**
+     * @brief Interact with objects within the organism's body size range.
+     * @param interactableObjects Objects overlapping the organism's size radius.
+     *
+     * Eats available food (gaining its energy) and kills smaller organisms
+     * (absorbing their remaining lifespan). Must run single-threaded because
+     * it mutates shared state (food eaten flags, other organisms' lifespans).
+     */
     void interact(const std::vector<std::shared_ptr<EnvironmentObject>> &interactableObjects);
+
+    /**
+     * @brief Create a mutated offspring organism.
+     * @return A new organism with mutated genes, inheriting the life consumption calculator.
+     *
+     * The parent's lifespan is halved. The child is placed at a small offset
+     * from the parent's position.
+     */
     std::shared_ptr<Organism> reproduce();
 
+    /**
+     * @brief End-of-iteration hook: deduct life consumption, kill if depleted, then move.
+     */
     void postIteration() override;
 
 private:
-    Genes genes;
-    LifeConsumptionCalculator lifeConsumptionCalculator;
-    float lifeSpan;
+    Genes genes;                                           ///< Genetic data driving attributes
+    LifeConsumptionCalculator lifeConsumptionCalculator;   ///< Optional custom life drain formula
+    float lifeSpan;                                        ///< Remaining life points
 
+    /**
+     * @brief Compute Euclidean distance to another environment object.
+     * @param object The target object.
+     * @return Distance in environment coordinate units.
+     */
     double calculateDistance(const std::shared_ptr<EnvironmentObject> &object) const;
 
-    std::pair<float, float> movement;
-    int reactionCounter = 0;
+    std::pair<float, float> movement;  ///< Current movement direction vector
+    int reactionCounter = 0;           ///< Guards against multiple reactions per tick
+
+    /**
+     * @brief Apply the current movement vector to update position.
+     *
+     * If no reaction occurred this tick, either keeps the previous movement
+     * (80% chance) or picks a new random direction. Normalizes movement to
+     * not exceed the organism's speed.
+     */
     void makeMove();
 };
 

--- a/include/core/Organism.hpp
+++ b/include/core/Organism.hpp
@@ -29,14 +29,12 @@ public:
     void killed();
     bool isAlive() const;
     bool canReproduce() const;
-    // [TODO] from GPT don't know if it is a good idea to make this virtual for python to override
-    // virtual bool isFull() const;
 
     ~Organism() {};
 
     // actions
-    void react(std::vector<std::shared_ptr<EnvironmentObject>> &reactableObjects);
-    void interact(std::vector<std::shared_ptr<EnvironmentObject>> &interactableObjects);
+    void react(const std::vector<std::shared_ptr<EnvironmentObject>> &reactableObjects);
+    void interact(const std::vector<std::shared_ptr<EnvironmentObject>> &interactableObjects);
     std::shared_ptr<Organism> reproduce();
 
     void postIteration() override;
@@ -46,7 +44,7 @@ private:
     LifeConsumptionCalculator lifeConsumptionCalculator;
     float lifeSpan;
 
-    double calculateDistance(std::shared_ptr<EnvironmentObject> object);
+    double calculateDistance(const std::shared_ptr<EnvironmentObject> &object) const;
 
     std::pair<float, float> movement;
     int reactionCounter = 0;

--- a/src/core/Environment.cpp
+++ b/src/core/Environment.cpp
@@ -8,23 +8,11 @@
 #include <utils/profiler.hpp>
 #include <vector>
 
-/**
- * @brief Constructor for Environment class.
- *
- * Initializes the Environment with given dimensions and a specific type of
- * spatial index.
- *
- * @param width The width of the environment.
- * @param height The height of the environment.
- * @param type The type of spatial index to use ("default" or "optimized").
- * @throws std::invalid_argument If an unrecognized type is provided.
- */
 Environment::Environment(int width, int height, std::string type, int numThreads)
     : width(width), height(height), type(type), numThreads(numThreads) {
     if (type == "default") {
         spatialIndex = std::make_unique<DefaultSpatialIndex<boost::uuids::uuid>>();
     } else if (type == "optimized") {
-        // setting the size of the spatial index to the longest side of the environment
         unsigned long size = static_cast<unsigned long>(std::max(width, height));
         spatialIndex = std::make_unique<OptimizedSpatialIndex<boost::uuids::uuid>>(size);
     } else {
@@ -32,32 +20,12 @@ Environment::Environment(int width, int height, std::string type, int numThreads
     }
 }
 
-/**
- * @brief Checks if the given coordinates are within the environment boundaries.
- *
- * Throws an exception if the coordinates are out of the allowed range.
- *
- * @param x The x-coordinate to check.
- * @param y The y-coordinate to check.
- * @throws std::out_of_range If coordinates are out of the environment
- * boundaries.
- */
 void Environment::checkBounds(float x, float y) const {
     if (x < 0.0f || x > static_cast<float>(width) || y < 0.0f || y > static_cast<float>(height)) {
-        // printf("Coordinates are out of the allowed range: (%f, %f)\n", x, y);
         throw std::out_of_range("Coordinates are out of the allowed range.");
     }
 }
 
-/**
- * @brief Adds an organism to the environment at specified coordinates.
- *
- * Inserts the organism into the spatial index and the objects map.
- *
- * @param organism A shared pointer to the organism to add.
- * @param x The x-coordinate where the organism will be placed.
- * @param y The y-coordinate where the organism will be placed.
- */
 void Environment::add(const std::shared_ptr<Organism>& organism, float x, float y) {
     checkBounds(x, y);
     auto id = organism->getId();
@@ -66,15 +34,6 @@ void Environment::add(const std::shared_ptr<Organism>& organism, float x, float 
     objectsMapper.insert({id, organism});
 }
 
-/**
- * brief Adds a food item to the environment at specified coordinates.
- *
- * Inserts the food item into the spatial index and the objects map.
- *
- * @param food A shared pointer to the food item to add.
- * @param x The x-coordinate where the food item will be placed.
- * @param y The y-coordinate where the food item will be placed.
- */
 void Environment::add(const std::shared_ptr<Food>& food, float x, float y) {
     checkBounds(x, y);
     auto id = food->getId();
@@ -83,41 +42,22 @@ void Environment::add(const std::shared_ptr<Food>& food, float x, float y) {
     objectsMapper.insert({id, food});
 }
 
-/**
- * @brief Removes an organism from the environment.
- *
- * Removes the organism from the spatial index and the objects map.
- *
- * @param organism A shared pointer to the organism to remove.
- */
 void Environment::remove(const std::shared_ptr<Organism>& organism) {
     if (objectsMapper.find(organism->getId()) == objectsMapper.end()) {
         throw std::runtime_error("Organism not found in Environment.");
     }
-
     spatialIndex->remove(organism->getId());
     objectsMapper.erase(organism->getId());
 }
 
-/**
- * brief Removes a food item from the environment.
- *
- * Removes the food item from the spatial index and the objects map.
- *
- * @param food A shared pointer to the food item to remove.
- */
 void Environment::remove(const std::shared_ptr<Food>& food) {
     if (objectsMapper.find(food->getId()) == objectsMapper.end()) {
         throw std::runtime_error("Food not found in Environment.");
     }
-
     spatialIndex->remove(food->getId());
     objectsMapper.erase(food->getId());
 }
 
-/**
- * @brief Resets the environment by clearing the spatial index and object map.
- */
 void Environment::reset() {
     spatialIndex->clear();
     objectsMapper.clear();
@@ -125,15 +65,6 @@ void Environment::reset() {
     foodConsumption = 0;
 }
 
-/**
- * @brief Simulates a number of iterations of the environment.
- *
- * Each iteration includes handling interactions, a post-iteration update, and
- * calling a callback function.
- *
- * @param iterations Number of iterations to simulate.
- * @param on_each_iteration Callback function to be called after each iteration.
- */
 void Environment::simulateIteration(int iterations,
                                     std::function<void(const Environment&)> on_each_iteration) {
     Profiler& profiler = Profiler::getInstance();
@@ -141,7 +72,7 @@ void Environment::simulateIteration(int iterations,
 
     profiler.start("simulateIteration");
     for (int i = 0; i < iterations; i++) {
-        if (getAllOrganisms().size() == 0 && getAllFoods().size() == 0) {
+        if (getAllOrganisms().empty() && getAllFoods().empty()) {
             break;
         }
 
@@ -203,108 +134,74 @@ std::vector<std::shared_ptr<Organism>> Environment::getDeadOrganisms() const {
 
 unsigned long Environment::getFoodConsumptionInIteration() const { return foodConsumption; }
 
-/**
- * @brief Updates and cleans up the environment after each iteration.
- *
- * Removes dead organisms and consumed food, and updates the positions of all
- * active organisms.
- */
 void Environment::postIteration() {
-    // do the post iteration for all objects
     for (auto& object : objectsMapper) {
         object.second->postIteration();
     }
-
     updatePositionsInSpatialIndex();
 }
 
-/**
- * @brief Updates the positions of all organisms in the spatial index, ensuring
- * they remain within bounds.
- */
 void Environment::updatePositionsInSpatialIndex() {
     for (auto& object : objectsMapper) {
         auto organism = std::dynamic_pointer_cast<Organism>(object.second);
         if (organism && organism->isAlive()) {
             auto [x, y] = organism->getPosition();
 
-            // make organism stay within bounds
             x = std::max(0.0f, std::min(static_cast<float>(width), x));
             y = std::max(0.0f, std::min(static_cast<float>(height), y));
 
             organism->setPosition(x, y);
-
             spatialIndex->update(object.first, x, y);
         }
     }
 }
 
-/**
- * @brief Manages interactions between all EnvironmentObjects with others by size
- *
- */
+// Interactions mutate shared state (food eaten, organism killed, lifeSpan changes),
+// so this phase runs single-threaded to avoid data races.
 void Environment::handleInteractions() {
-    std::vector<std::thread> threads;
+    auto organisms = getAllOrganisms();
 
-    // each thread will handle interactions for a subset of organisms
-    auto worker = [&](int thread_id) {
-        auto organisms = getAllOrganisms();
-        size_t chunkSize = organisms.size() / numThreads;
-        size_t start = thread_id * chunkSize;
-        size_t end = (thread_id == numThreads - 1) ? organisms.size() : (thread_id + 1) * chunkSize;
+    for (auto& organism : organisms) {
+        if (organism->isAlive()) {
+            auto position = organism->getPosition();
+            auto interactables =
+                spatialIndex->query(position.first, position.second, organism->getSize());
+            std::vector<std::shared_ptr<EnvironmentObject>> interactableObjects;
 
-        for (size_t i = start; i < end; ++i) {
-            auto organism = organisms[i];
-            if (organism->isAlive()) {
-                std::pair<float, float> position = organism->getPosition();
-                std::vector<boost::uuids::uuid> interactables =
-                    spatialIndex->query(position.first, position.second, organism->getSize());
-                std::vector<std::shared_ptr<EnvironmentObject>> interactableObjects;
-
-                for (auto& interactable : interactables) {
-                    if (interactable != organism->getId()) {
-                        interactableObjects.push_back(objectsMapper[interactable]);
+            for (auto& interactable : interactables) {
+                if (interactable != organism->getId()) {
+                    auto it = objectsMapper.find(interactable);
+                    if (it != objectsMapper.end()) {
+                        interactableObjects.push_back(it->second);
                     }
                 }
-
-                organism->interact(interactableObjects);
             }
-        }
-    };
 
-    for (int i = 0; i < numThreads; ++i) {
-        threads.emplace_back(worker, i);
-    }
-
-    for (auto& thread : threads) {
-        if (thread.joinable()) {
-            thread.join();
+            organism->interact(interactableObjects);
         }
     }
 }
 
-/**
- * @brief Manages reactions between all living organisms with others by radius
- *
- */
+// Reactions only write to each organism's own movement/reactionCounter fields,
+// so this phase is safe to parallelize across organisms.
 void Environment::handleReactions() {
-    std::vector<std::thread> threads;
-    auto worker = [&](int thread_id) {
-        auto organisms = getAllOrganisms();
-        size_t chunkSize = organisms.size() / numThreads;
-        size_t start = thread_id * chunkSize;
-        size_t end = (thread_id == numThreads - 1) ? organisms.size() : (thread_id + 1) * chunkSize;
+    auto organisms = getAllOrganisms();
+    if (organisms.empty()) return;
 
+    auto worker = [&](size_t start, size_t end) {
         for (size_t i = start; i < end; ++i) {
-            auto organism = organisms[i];
+            auto& organism = organisms[i];
             if (organism->isAlive()) {
-                std::pair<float, float> position = organism->getPosition();
-                std::vector<boost::uuids::uuid> reactables = spatialIndex->query(
+                auto position = organism->getPosition();
+                auto reactables = spatialIndex->query(
                     position.first, position.second, organism->getReactionRadius());
                 std::vector<std::shared_ptr<EnvironmentObject>> reactableObjects;
                 for (auto& reactable : reactables) {
                     if (reactable != organism->getId()) {
-                        reactableObjects.push_back(objectsMapper[reactable]);
+                        auto it = objectsMapper.find(reactable);
+                        if (it != objectsMapper.end()) {
+                            reactableObjects.push_back(it->second);
+                        }
                     }
                 }
 
@@ -313,21 +210,24 @@ void Environment::handleReactions() {
         }
     };
 
-    for (int i = 0; i < numThreads; ++i) {
-        threads.emplace_back(worker, i);
-    }
+    if (numThreads <= 1) {
+        worker(0, organisms.size());
+    } else {
+        std::vector<std::thread> threads;
+        size_t chunkSize = organisms.size() / numThreads;
 
-    for (auto& thread : threads) {
-        if (thread.joinable()) {
+        for (int i = 0; i < numThreads; ++i) {
+            size_t start = i * chunkSize;
+            size_t end = (i == numThreads - 1) ? organisms.size() : (i + 1) * chunkSize;
+            threads.emplace_back(worker, start, end);
+        }
+
+        for (auto& thread : threads) {
             thread.join();
         }
     }
 }
 
-/** @brief Retrieves all objects currently in the environment.
- *
- * @return std::vector<std::shared_ptr<EnvironmentObject>> A list of all objects.
- */
 std::vector<std::shared_ptr<EnvironmentObject>> Environment::getAllObjects() const {
     std::vector<std::shared_ptr<EnvironmentObject>> objects;
     for (const auto& object : objectsMapper) {
@@ -336,11 +236,6 @@ std::vector<std::shared_ptr<EnvironmentObject>> Environment::getAllObjects() con
     return objects;
 }
 
-/**
- * @brief Retrieves all organisms currently in the environment.
- *
- * @return std::vector<std::shared_ptr<Organism>> A list of all organisms.
- */
 std::vector<std::shared_ptr<Organism>> Environment::getAllOrganisms() const {
     std::vector<std::shared_ptr<Organism>> organisms;
     for (const auto& object : objectsMapper) {
@@ -351,11 +246,6 @@ std::vector<std::shared_ptr<Organism>> Environment::getAllOrganisms() const {
     return organisms;
 }
 
-/**
- * @brief Retrieves all food items currently in the environment.
- *
- * @return std::vector<std::shared_ptr<Food>> A list of all food items.
- */
 std::vector<std::shared_ptr<Food>> Environment::getAllFoods() const {
     std::vector<std::shared_ptr<Food>> foods;
     for (const auto& object : objectsMapper) {

--- a/src/core/Environment.cpp
+++ b/src/core/Environment.cpp
@@ -8,6 +8,14 @@
 #include <utils/profiler.hpp>
 #include <vector>
 
+/**
+ * @brief Construct an environment with the given dimensions and spatial index type.
+ * @param width  Environment width in simulation units.
+ * @param height Environment height in simulation units.
+ * @param type   Spatial index type: "default" or "optimized".
+ * @param numThreads Number of threads for the parallel reaction phase.
+ * @throws std::invalid_argument If the spatial index type is unknown.
+ */
 Environment::Environment(int width, int height, std::string type, int numThreads)
     : width(width), height(height), type(type), numThreads(numThreads) {
     if (type == "default") {
@@ -20,12 +28,25 @@ Environment::Environment(int width, int height, std::string type, int numThreads
     }
 }
 
+/**
+ * @brief Validate that coordinates are within environment boundaries.
+ * @param x X coordinate.
+ * @param y Y coordinate.
+ * @throws std::out_of_range If coordinates exceed [0, width] x [0, height].
+ */
 void Environment::checkBounds(float x, float y) const {
     if (x < 0.0f || x > static_cast<float>(width) || y < 0.0f || y > static_cast<float>(height)) {
         throw std::out_of_range("Coordinates are out of the allowed range.");
     }
 }
 
+/**
+ * @brief Add an organism to the environment at the specified position.
+ * @param organism Shared pointer to the organism.
+ * @param x X coordinate.
+ * @param y Y coordinate.
+ * @throws std::out_of_range If coordinates are out of bounds.
+ */
 void Environment::add(const std::shared_ptr<Organism>& organism, float x, float y) {
     checkBounds(x, y);
     auto id = organism->getId();
@@ -34,6 +55,13 @@ void Environment::add(const std::shared_ptr<Organism>& organism, float x, float 
     objectsMapper.insert({id, organism});
 }
 
+/**
+ * @brief Add a food item to the environment at the specified position.
+ * @param food Shared pointer to the food.
+ * @param x X coordinate.
+ * @param y Y coordinate.
+ * @throws std::out_of_range If coordinates are out of bounds.
+ */
 void Environment::add(const std::shared_ptr<Food>& food, float x, float y) {
     checkBounds(x, y);
     auto id = food->getId();
@@ -42,6 +70,11 @@ void Environment::add(const std::shared_ptr<Food>& food, float x, float y) {
     objectsMapper.insert({id, food});
 }
 
+/**
+ * @brief Remove an organism from the environment.
+ * @param organism Shared pointer to the organism to remove.
+ * @throws std::runtime_error If the organism is not found.
+ */
 void Environment::remove(const std::shared_ptr<Organism>& organism) {
     if (objectsMapper.find(organism->getId()) == objectsMapper.end()) {
         throw std::runtime_error("Organism not found in Environment.");
@@ -50,6 +83,11 @@ void Environment::remove(const std::shared_ptr<Organism>& organism) {
     objectsMapper.erase(organism->getId());
 }
 
+/**
+ * @brief Remove a food item from the environment.
+ * @param food Shared pointer to the food to remove.
+ * @throws std::runtime_error If the food is not found.
+ */
 void Environment::remove(const std::shared_ptr<Food>& food) {
     if (objectsMapper.find(food->getId()) == objectsMapper.end()) {
         throw std::runtime_error("Food not found in Environment.");
@@ -58,6 +96,9 @@ void Environment::remove(const std::shared_ptr<Food>& food) {
     objectsMapper.erase(food->getId());
 }
 
+/**
+ * @brief Reset the environment, removing all objects and clearing statistics.
+ */
 void Environment::reset() {
     spatialIndex->clear();
     objectsMapper.clear();
@@ -65,6 +106,16 @@ void Environment::reset() {
     foodConsumption = 0;
 }
 
+/**
+ * @brief Run the simulation for the specified number of iterations.
+ * @param iterations Number of iterations to simulate.
+ * @param on_each_iteration Optional callback invoked after each iteration.
+ *
+ * Each iteration runs three phases in order:
+ * 1. handleInteractions (single-threaded) -- organisms eat food / prey on others.
+ * 2. handleReactions (multi-threaded) -- organisms decide movement direction.
+ * 3. postIteration -- deduct life, move organisms, sync spatial index.
+ */
 void Environment::simulateIteration(int iterations,
                                     std::function<void(const Environment&)> on_each_iteration) {
     Profiler& profiler = Profiler::getInstance();
@@ -108,6 +159,12 @@ void Environment::simulateIteration(int iterations,
     printf("_______________________________________________________\n");
 }
 
+/**
+ * @brief Remove dead organisms and consumed food from the environment.
+ *
+ * Dead organisms are archived in deadOrganisms for post-simulation analysis.
+ * Consumed food increments the foodConsumption counter.
+ */
 void Environment::cleanUp() {
     std::vector<boost::uuids::uuid> toRemove;
     for (const auto& object : objectsMapper) {
@@ -128,12 +185,17 @@ void Environment::cleanUp() {
     }
 }
 
+/** @brief Get the list of organisms that died during the simulation. */
 std::vector<std::shared_ptr<Organism>> Environment::getDeadOrganisms() const {
     return deadOrganisms;
 }
 
+/** @brief Get the total number of food items consumed across all iterations. */
 unsigned long Environment::getFoodConsumptionInIteration() const { return foodConsumption; }
 
+/**
+ * @brief Run per-object post-iteration logic, then sync positions with the spatial index.
+ */
 void Environment::postIteration() {
     for (auto& object : objectsMapper) {
         object.second->postIteration();
@@ -141,12 +203,18 @@ void Environment::postIteration() {
     updatePositionsInSpatialIndex();
 }
 
+/**
+ * @brief Synchronize organism positions with the spatial index after movement.
+ *
+ * Clamps organism positions within environment bounds before updating the index.
+ */
 void Environment::updatePositionsInSpatialIndex() {
     for (auto& object : objectsMapper) {
         auto organism = std::dynamic_pointer_cast<Organism>(object.second);
         if (organism && organism->isAlive()) {
             auto [x, y] = organism->getPosition();
 
+            // Clamp organism position within environment bounds
             x = std::max(0.0f, std::min(static_cast<float>(width), x));
             y = std::max(0.0f, std::min(static_cast<float>(height), y));
 
@@ -213,6 +281,7 @@ void Environment::handleReactions() {
     if (numThreads <= 1) {
         worker(0, organisms.size());
     } else {
+        // Partition organisms evenly across threads; last thread handles remainder
         std::vector<std::thread> threads;
         size_t chunkSize = organisms.size() / numThreads;
 
@@ -228,6 +297,7 @@ void Environment::handleReactions() {
     }
 }
 
+/** @brief Get all objects (organisms and food) in the environment. */
 std::vector<std::shared_ptr<EnvironmentObject>> Environment::getAllObjects() const {
     std::vector<std::shared_ptr<EnvironmentObject>> objects;
     for (const auto& object : objectsMapper) {
@@ -236,6 +306,7 @@ std::vector<std::shared_ptr<EnvironmentObject>> Environment::getAllObjects() con
     return objects;
 }
 
+/** @brief Get all living and dead organisms currently in the environment. */
 std::vector<std::shared_ptr<Organism>> Environment::getAllOrganisms() const {
     std::vector<std::shared_ptr<Organism>> organisms;
     for (const auto& object : objectsMapper) {
@@ -246,6 +317,7 @@ std::vector<std::shared_ptr<Organism>> Environment::getAllOrganisms() const {
     return organisms;
 }
 
+/** @brief Get all food items currently in the environment. */
 std::vector<std::shared_ptr<Food>> Environment::getAllFoods() const {
     std::vector<std::shared_ptr<Food>> foods;
     for (const auto& object : objectsMapper) {

--- a/src/core/Genes.cpp
+++ b/src/core/Genes.cpp
@@ -15,8 +15,8 @@ Genes::Genes(const char *dnaStr, MutationFunction customMutationLogic = nullptr)
 }
 
 void Genes::defaultMutationLogic(char dna[4]) {
-    static std::mt19937 rng(std::random_device{}());         // Seed with random_device
-    std::uniform_int_distribution<int> distribution(-3, 3);  // Range from -10 to 10
+    static thread_local std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> distribution(-3, 3);
 
     for (int i = 0; i < 4; ++i) {
         int mutation = distribution(rng);  // Generate a random mutation from -1 to 1

--- a/src/core/Genes.cpp
+++ b/src/core/Genes.cpp
@@ -5,25 +5,38 @@
 
 Genes::Genes(const char *dnaStr) : Genes(dnaStr, nullptr) {
     std::memcpy(dna, dnaStr, 4);
-    // printf("Genes %s is being created with %u %u %u %u\n", dnaStr, dna[0], dna[1], dna[2], dna[3]);
 }
 
 Genes::Genes(const char *dnaStr, MutationFunction customMutationLogic = nullptr)
     : mutationLogic(customMutationLogic ? customMutationLogic : defaultMutationLogic) {
     std::memcpy(dna, dnaStr, 4);
-    // printf("Genes %s is being created with %u %u %u %u\n", dnaStr, dna[0], dna[1], dna[2], dna[3]);
 }
 
+/**
+ * @brief Default mutation: randomly adjusts each gene by -3 to +3.
+ * @param dna Array of 4 gene bytes (each 0-255) to mutate in place.
+ *
+ * Uses thread_local RNG so this is safe to call from multiple threads
+ * during the parallel reaction phase.
+ */
 void Genes::defaultMutationLogic(char dna[4]) {
+    // thread_local ensures each thread gets its own RNG instance for thread safety
     static thread_local std::mt19937 rng(std::random_device{}());
+    // Mutation range: each gene shifts by -3 to +3 per generation
     std::uniform_int_distribution<int> distribution(-3, 3);
 
     for (int i = 0; i < 4; ++i) {
-        int mutation = distribution(rng);  // Generate a random mutation from -1 to 1
+        int mutation = distribution(rng);
         dna[i] += mutation;
     }
 }
 
+/** @brief Apply the mutation function to this organism's DNA. */
 void Genes::mutate() { mutationLogic(dna); }
 
+/**
+ * @brief Access a specific gene value.
+ * @param index Gene index (0=speed, 1=size, 2=awareness, 3=reserved).
+ * @return Raw gene value as a char (0-255).
+ */
 char Genes::getDNA(int index) const { return dna[index]; }

--- a/src/core/Organism.cpp
+++ b/src/core/Organism.cpp
@@ -1,8 +1,6 @@
-#include <boost/uuid/uuid_io.hpp>
 #include <core/Food.hpp>
 #include <core/Organism.hpp>
 #include <cstdio>
-#include <iostream>
 #include <random>
 
 Organism::Organism() : EnvironmentObject(0, 0), genes("\x14\x14\x14\x14"), lifeSpan(500) {}
@@ -13,15 +11,15 @@ Organism::Organism(const Genes& genes, LifeConsumptionCalculator calculator)
     : EnvironmentObject(0, 0), genes(genes), lifeConsumptionCalculator(calculator), lifeSpan(500) {}
 
 float Organism::getSpeed() const {
-    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(0))) / 4.0f;  // 256 / 4 = 64
+    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(0))) / 4.0f;
 }
 
 float Organism::getSize() const {
-    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(1))) / 4.0f;  // 256 / 4 = 64
+    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(1))) / 4.0f;
 }
 
 float Organism::getAwareness() const {
-    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(2))) / 4.0f;  // 256 / 4 = 64
+    return static_cast<float>(static_cast<unsigned char>(genes.getDNA(2))) / 4.0f;
 }
 
 float Organism::getLifeConsumption() const {
@@ -29,13 +27,9 @@ float Organism::getLifeConsumption() const {
         return lifeConsumptionCalculator(*this);
     }
 
-    // printf("Organism %s is getting speed %f, size %f, awareness %f\n",
-    //  boost::uuids::to_string(getId()).c_str(), getSpeed(), getSize(), getAwareness());
     float consumption =
         (getSpeed() / 10 * getSpeed() / 10 + getSize() / 10 * getSize() / 10 * getSize() / 15 +
         getAwareness() / 10) * 1.3;
-    // printf("Organism %s is getting life consumption %f\n",
-    //        boost::uuids::to_string(getId()).c_str(), consumption);
     return consumption;
 }
 
@@ -45,39 +39,27 @@ float Organism::getReactionRadius() const { return getSize() + getAwareness(); }
 
 bool Organism::isAlive() const { return lifeSpan > 0; }
 
-bool Organism::canReproduce() const { return lifeSpan > 1000; } 
+bool Organism::canReproduce() const { return lifeSpan > 1000; }
 
-// bool Organism::isFull() const {
-//     printf("Organism thinking whether it is full\n");
-//     return lifeSpan > getSize() * 50 * 2;
-// }  // *50 nom to lifespan and *2 to at least reproduce
-
-double Organism::calculateDistance(std::shared_ptr<EnvironmentObject> object) {
-    auto dx = getPosition().first - object->getPosition().first;
-    auto dy = getPosition().second - object->getPosition().second;
+double Organism::calculateDistance(const std::shared_ptr<EnvironmentObject>& object) const {
+    auto pos = getPosition();
+    auto otherPos = object->getPosition();
+    auto dx = pos.first - otherPos.first;
+    auto dy = pos.second - otherPos.second;
     return std::sqrt(dx * dx + dy * dy);
 }
 
-void Organism::react(std::vector<std::shared_ptr<EnvironmentObject>>& reactableObjects) {
+void Organism::react(const std::vector<std::shared_ptr<EnvironmentObject>>& reactableObjects) {
     if (reactableObjects.empty()) {
-        // printf("Organism %s is not reacting to any objects\n",
-        //  boost::uuids::to_string(getId()).c_str());
         return;
     }
-    // printf("Organism %s is reacting to the other objects\n",
-    //  boost::uuids::to_string(getId()).c_str());
 
     std::shared_ptr<EnvironmentObject> nearestObject = nullptr;
     double minDistance = std::numeric_limits<double>::max();
 
-    // printf("Organism %s is calculating the nearest object\n",
-    // boost::uuids::to_string(getId()).c_str());
-
-    // Find the nearest valid object
     for (const auto& obj : reactableObjects) {
         if (auto food = std::dynamic_pointer_cast<Food>(obj)) {
             if (!food->canBeEaten()) {
-                // printf("Organism %s is ignoring the food\n", boost::uuids::to_string(getId()).c_str());
                 continue;
             }
         } else if (auto organism = std::dynamic_pointer_cast<Organism>(obj)) {
@@ -94,31 +76,24 @@ void Organism::react(std::vector<std::shared_ptr<EnvironmentObject>>& reactableO
     }
 
     if (!nearestObject) {
-        // printf("Organism %s found no valid objects to react to\n",
-        // boost::uuids::to_string(getId()).c_str());
         return;
     }
 
+    auto myPos = getPosition();
+
     if (auto otherOrganism = std::dynamic_pointer_cast<Organism>(nearestObject)) {
-        if (reactionCounter != 0) {  // already decided to move
+        if (reactionCounter != 0) {
             return;
         }
 
+        auto otherPos = otherOrganism->getPosition();
         if (getSize() * 1.5 < otherOrganism->getSize()) {
-            // printf("Organism %s is running away from organism %s\n",
-            //        boost::uuids::to_string(getId()).c_str(),
-            //        boost::uuids::to_string(otherOrganism->getId()).c_str());
-            // run away from the other organism
-            movement = std::make_pair(getPosition().first - otherOrganism->getPosition().first,
-                                      getPosition().second - otherOrganism->getPosition().second);
+            movement = std::make_pair(myPos.first - otherPos.first,
+                                      myPos.second - otherPos.second);
             reactionCounter++;
         } else if (getSize() > 1.5 * otherOrganism->getSize()) {
-            // printf("Organism %s is chasing organism %s\n",
-            // boost::uuids::to_string(getId()).c_str(),
-            //        boost::uuids::to_string(otherOrganism->getId()).c_str());
-            // trace the other organism
-            movement = std::make_pair(otherOrganism->getPosition().first - getPosition().first,
-                                      otherOrganism->getPosition().second - getPosition().second);
+            movement = std::make_pair(otherPos.first - myPos.first,
+                                      otherPos.second - myPos.second);
             reactionCounter++;
         }
     } else if (auto food = std::dynamic_pointer_cast<Food>(nearestObject)) {
@@ -126,50 +101,25 @@ void Organism::react(std::vector<std::shared_ptr<EnvironmentObject>>& reactableO
             return;
         }
 
-        // if (isFull()) {
-        // if (lifeSpan > 1200) {
-            // printf("Organism of size %f is full\n", getSize());
-            // This constraint is added to prevent the organism from eating food when it is full
-        //     return;
-        // }
-
-        // printf("Organism %s is moving to the food \n", boost::uuids::to_string(getId()).c_str());
         reactionCounter++;
-
-        movement = std::make_pair(food->getPosition().first - getPosition().first,
-                                  food->getPosition().second - getPosition().second);
+        auto foodPos = food->getPosition();
+        movement = std::make_pair(foodPos.first - myPos.first,
+                                  foodPos.second - myPos.second);
     } else {
         throw std::runtime_error("Unknown object type detected");
     }
 }
 
-// In Organism::interact
-void Organism::interact(std::vector<std::shared_ptr<EnvironmentObject>>& interactableObjects) {
-    // printf("Organism %s is interacting with the other objects\n",
-    //  boost::uuids::to_string(getId()).c_str());
-    for (auto& object : interactableObjects) {
+void Organism::interact(const std::vector<std::shared_ptr<EnvironmentObject>>& interactableObjects) {
+    for (const auto& object : interactableObjects) {
         if (auto food = std::dynamic_pointer_cast<Food>(object)) {
             if (!food->canBeEaten()) continue;
-
-            // std::cout << "Organism " << this->getId() << " is eating food. Life span: " <<
-            // lifeSpan
-            //           << " + " << food->getEnergy() << std::endl;
-            lifeSpan += food->getEnergy();
             food->eaten();
+            lifeSpan += food->getEnergy();
         }
 
         if (auto organism = std::dynamic_pointer_cast<Organism>(object)) {
-            // printf(
-            //  "Organism %s is interacting with organism %s, it will be %s after interaction. \n",
-            //  boost::uuids::to_string(getId()).c_str(),
-            //  boost::uuids::to_string(organism->getId()).c_str(),
-            //  getSize() > 4 * organism->getSize() ? "killed" : "alive");
-            // printf("Organism %s is %f, %f, %f, organism %s is %f, %f, %f\n",
-            //  boost::uuids::to_string(getId()).c_str(), getSpeed(), getSize(), getAwareness(),
-            //  boost::uuids::to_string(organism->getId()).c_str(), organism->getSpeed(),
-            //  organism->getSize(), organism->getAwareness());
-
-            if (getSize() > 1.5 * organism->getSize()) {
+            if (getSize() > 1.5 * organism->getSize() && organism->isAlive()) {
                 lifeSpan += organism->getLifeSpan();
                 organism->killed();
             }
@@ -178,15 +128,9 @@ void Organism::interact(std::vector<std::shared_ptr<EnvironmentObject>>& interac
 }
 
 std::shared_ptr<Organism> Organism::reproduce() {
-    // copy the gene than mutate and create a new organism
-    // printf("Organism %s is reproducing, it attr is (%f, %f, %f) \n",
-    //        boost::uuids::to_string(getId()).c_str(), getSpeed(), getSize(), getAwareness());
     Genes newGenes = genes;
     newGenes.mutate();
     auto newOrganism = std::make_shared<Organism>(newGenes, lifeConsumptionCalculator);
-    // printf("New organism %s is created, it attr is (%f, %f, %f) \n",
-    //  boost::uuids::to_string(newOrganism->getId()).c_str(), newOrganism->getSpeed(),
-    //  newOrganism->getSize(), newOrganism->getAwareness());
     newOrganism->setPosition(getPosition().first + 2, getPosition().second + 2);
     lifeSpan /= 2;
     return newOrganism;
@@ -195,39 +139,24 @@ std::shared_ptr<Organism> Organism::reproduce() {
 void Organism::killed() { lifeSpan = 0; }
 
 void Organism::postIteration() {
-    // printf("Organism %s is at (%f, %f) %f %f (%f, %f, %f)\n",
-    //  boost::uuids::to_string(getId()).c_str(), getPosition().first, getPosition().second,
-    //  lifeSpan, getLifeConsumption(), getSpeed(), getSize(), getAwareness());
-
     lifeSpan -= getLifeConsumption();
 
-    // printf("Organism %s life span: %f\n", boost::uuids::to_string(getId()).c_str(), lifeSpan);
     if (lifeSpan <= 0) {
         killed();
         return;
     }
 
-    // printf("Organism %s is at (%f, %f), movement: (%f, %f), reaction counter: %d\n",
-    //  boost::uuids::to_string(getId()).c_str(), getPosition().first, getPosition().second,
-    //  movement.first, movement.second, reactionCounter);
-
     makeMove();
 }
 
-// make move have to calculate the movement of the organism
-// the movement length is determined by the organism's speed
 void Organism::makeMove() {
-    // Initialize local random engine and distributions
-    static std::random_device rd;                    // Non-deterministic seed
-    static std::mt19937 gen(rd());                   // Standard mersenne_twister_engine
-    std::uniform_int_distribution<int> dis(0, 4);    // Distribution for movement decision
-    std::uniform_int_distribution<int> move(-1, 1);  // Distribution for movement direction
+    static thread_local std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<int> dis(0, 4);
+    std::uniform_int_distribution<int> move(-1, 1);
 
     auto speed = getSpeed();
 
     if (reactionCounter == 0) {
-        // Determine to keep the movement or generate a new one
-        // 80% chance to keep the movement
         bool keepMovement = dis(gen) > 0;
         if (movement.first == 0 && movement.second == 0) {
             keepMovement = false;
@@ -238,7 +167,6 @@ void Organism::makeMove() {
         }
     }
 
-    // Adjust the movement length to not exceed the speed of the organism
     auto movementLength =
         std::sqrt(movement.first * movement.first + movement.second * movement.second);
     if (movementLength > speed) {
@@ -249,5 +177,5 @@ void Organism::makeMove() {
 
     setPosition(getPosition().first + movement.first, getPosition().second + movement.second);
 
-    reactionCounter = 0;  // Reset reaction counter after making a move
+    reactionCounter = 0;
 }


### PR DESCRIPTION
## Summary
- Make static RNG `thread_local` in `Organism::makeMove()` and `Genes::defaultMutationLogic()` to fix data races
- Pre-compute organism list once before thread dispatch instead of calling `getAllOrganisms()` per-thread (was doing N expensive `dynamic_pointer_cast` scans)
- Skip `std::thread` creation overhead when `numThreads=1`
- Make `handleInteractions` single-threaded since it mutates shared state (`food->eaten()`, `organism->killed()`, `lifeSpan` modifications)
- Keep `handleReactions` multi-threaded (safe: each thread only writes to its own organism's `movement`/`reactionCounter`)
- Use `std::atomic<FoodState>` for thread-safe food state transitions
- Use safe `objectsMapper.find()` instead of `operator[]` in threaded context
- Fix `shared_ptr` passed by value in `calculateDistance` (now const ref)
- Make `react()`/`interact()` take const vector references
- Remove dead `removeDeadOrganisms()` declaration
- Remove commented-out debug printf statements

## Discussion Points
- `handleInteractions` 目前改為 single-threaded 來避免 data race。如果未來需要平行化 interaction phase，可以考慮用 per-object lock 或將 interaction 結果收集後 batch apply
- `Food::canBeEaten()` 用 `std::atomic<FoodState>` 但兩個 organism 仍可能同時看到 `FRESH` 然後都加 energy。目前這是 acceptable 因為 interaction phase 已改為 single-threaded

## Test plan
- [x] All 3 existing Python tests pass
- [ ] Run benchmark example to verify no performance regression
- [ ] Test with `numThreads > 1` to verify reaction phase parallelism still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)