### PR TITLE
refactor: improve C++ code quality and add Vec2 type

### DIFF
--- a/bindings/core/Food_bindings.cpp
+++ b/bindings/core/Food_bindings.cpp
@@ -7,6 +7,8 @@ namespace py = pybind11;
 void init_Food(py::module &m) {
     py::class_<Food, EnvironmentObject, std::shared_ptr<Food>>(m, "Food")
         .def(py::init<>())
+        .def(py::init<int>(), py::arg("energy"))
         .def("can_be_eaten", &Food::canBeEaten)
-        .def("eaten", &Food::eaten);
+        .def("eaten", &Food::eaten)
+        .def("get_energy", &Food::getEnergy);
 }

--- a/include/core/Environment.hpp
+++ b/include/core/Environment.hpp
@@ -1,4 +1,3 @@
-// Environment.hpp
 #ifndef ENVIRONMENT_HPP
 #define ENVIRONMENT_HPP
 
@@ -108,7 +107,7 @@ private:
     std::unordered_map<boost::uuids::uuid, std::shared_ptr<EnvironmentObject>> objectsMapper;
 
     std::vector<std::shared_ptr<Organism>> deadOrganisms;  ///< Accumulated dead organisms
-    unsigned long foodConsumption;                         ///< Running food consumption counter
+    unsigned long foodConsumption = 0;                      ///< Running food consumption counter
 
     int numThreads = 1;  ///< Thread count for the parallelizable reaction phase
 

--- a/include/core/EnvironmentObject.hpp
+++ b/include/core/EnvironmentObject.hpp
@@ -4,24 +4,29 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
+#include "Vec2.hpp"
+
 class EnvironmentObject {
 public:
     EnvironmentObject(float x, float y)
-        : id(boost::uuids::random_generator()()), position(std::make_pair(x, y)) {}
+        : id(boost::uuids::random_generator()()), position(x, y) {}
 
     boost::uuids::uuid getId() const { return id; }
 
     virtual ~EnvironmentObject() = default;
-    virtual void postIteration() {};
+    virtual void postIteration() {}
 
-    // [TODO] change this - very bad implementation in order to make organism
-    // move
-    virtual std::pair<float, float> getPosition() const { return position; }
-    virtual void setPosition(float x, float y) { position = std::make_pair(x, y); }
+    std::pair<float, float> getPosition() const { return position; }
+    void setPosition(float x, float y) { position = Vec2(x, y); }
+
+    Vec2 getPos() const { return position; }
+    void setPos(Vec2 pos) { position = pos; }
 
 private:
     boost::uuids::uuid id;
-    std::pair<float, float> position;
+
+protected:
+    Vec2 position;
 };
 
 #endif

--- a/include/core/EnvironmentObject.hpp
+++ b/include/core/EnvironmentObject.hpp
@@ -6,27 +6,53 @@
 
 #include "Vec2.hpp"
 
+/**
+ * @brief Base class for all objects that exist in the simulation environment.
+ *
+ * Each object has a unique UUID identifier and a 2D position. Derived classes
+ * include Organism and Food. Position is stored as Vec2 and is accessible
+ * both as Vec2 (getPos/setPos) and as std::pair (getPosition/setPosition)
+ * for backward compatibility.
+ */
 class EnvironmentObject {
 public:
+    /**
+     * @brief Construct an environment object at the given coordinates.
+     * @param x Initial x position.
+     * @param y Initial y position.
+     */
     EnvironmentObject(float x, float y)
         : id(boost::uuids::random_generator()()), position(x, y) {}
 
+    /** @brief Get the unique identifier of this object. */
     boost::uuids::uuid getId() const { return id; }
 
     virtual ~EnvironmentObject() = default;
+
+    /** @brief Called at the end of each simulation iteration. Override in subclasses. */
     virtual void postIteration() {}
 
+    /** @brief Get position as a std::pair (legacy interface). */
     std::pair<float, float> getPosition() const { return position; }
+
+    /**
+     * @brief Set position from individual coordinates.
+     * @param x New x coordinate.
+     * @param y New y coordinate.
+     */
     void setPosition(float x, float y) { position = Vec2(x, y); }
 
+    /** @brief Get position as a Vec2. */
     Vec2 getPos() const { return position; }
+
+    /** @brief Set position from a Vec2. */
     void setPos(Vec2 pos) { position = pos; }
 
 private:
-    boost::uuids::uuid id;
+    boost::uuids::uuid id;  ///< Unique identifier for spatial-index lookups
 
 protected:
-    Vec2 position;
+    Vec2 position;  ///< Current position (accessible to subclasses)
 };
 
 #endif

--- a/include/core/Food.hpp
+++ b/include/core/Food.hpp
@@ -13,15 +13,21 @@ enum class FoodState { FRESH, EATEN };
 /**
  * @brief A consumable food item that organisms can eat to gain energy.
  *
- * Food objects exist in the environment and provide a fixed amount of energy
- * when consumed. Once eaten, the food transitions to the EATEN state and will
- * be cleaned up by the environment. Uses atomic state to allow safe concurrent
- * reads during the parallelizable reaction phase.
+ * Food objects exist in the environment and provide energy when consumed. Once
+ * eaten, the food transitions to the EATEN state and will be cleaned up by the
+ * environment. Uses atomic state to allow safe concurrent reads during the
+ * parallelizable reaction phase.
  */
 class Food : public EnvironmentObject {
 public:
     /** @brief Construct a Food object at the origin with default energy (500). */
     Food() : EnvironmentObject(0, 0) {}
+
+    /**
+     * @brief Construct food with a custom energy value.
+     * @param energy The amount of energy this food provides when consumed.
+     */
+    explicit Food(int energy) : EnvironmentObject(0, 0), energy(energy) {}
 
     /**
      * @brief Check whether this food is still available for consumption.
@@ -39,13 +45,14 @@ public:
 
     /**
      * @brief Get the energy value this food provides when consumed.
-     * @return Fixed energy value (500) added to the consuming organism's lifespan.
+     * @return Energy added to the consuming organism's lifespan.
      */
-    int getEnergy() const { return 500; }
+    int getEnergy() const { return energy; }
 
 private:
     /// Atomic state ensures safe concurrent access from the parallel reaction phase.
     std::atomic<FoodState> state{FoodState::FRESH};
+    int energy = 500;  ///< Energy granted to the organism that eats this food
 };
 
 #endif

--- a/include/core/Organism.hpp
+++ b/include/core/Organism.hpp
@@ -133,8 +133,8 @@ private:
      */
     double calculateDistance(const std::shared_ptr<EnvironmentObject> &object) const;
 
-    std::pair<float, float> movement;  ///< Current movement direction vector
-    int reactionCounter = 0;           ///< Guards against multiple reactions per tick
+    Vec2 movement;              ///< Current movement direction vector
+    int reactionCounter = 0;    ///< Guards against multiple reactions per tick
 
     /**
      * @brief Apply the current movement vector to update position.

--- a/include/core/Vec2.hpp
+++ b/include/core/Vec2.hpp
@@ -4,23 +4,49 @@
 #include <cmath>
 #include <utility>
 
+/**
+ * @brief A 2D vector struct used for positions and movement directions.
+ *
+ * Provides basic vector arithmetic, normalization, and implicit conversion
+ * to/from std::pair<float, float> for backward compatibility with legacy APIs.
+ */
 struct Vec2 {
-    float x = 0.0f;
-    float y = 0.0f;
+    float x = 0.0f;  ///< X component
+    float y = 0.0f;  ///< Y component
 
+    /// @brief Default constructor, initializes to (0, 0).
     Vec2() = default;
+
+    /**
+     * @brief Construct a Vec2 with given x and y components.
+     * @param x The x component.
+     * @param y The y component.
+     */
     Vec2(float x, float y) : x(x), y(y) {}
 
-    // Allow implicit conversion to/from std::pair for backward compatibility
+    /// @brief Implicit conversion from std::pair for backward compatibility.
     Vec2(const std::pair<float, float>& p) : x(p.first), y(p.second) {}
+
+    /// @brief Implicit conversion to std::pair for backward compatibility.
     operator std::pair<float, float>() const { return {x, y}; }
 
+    /// @brief Component-wise addition.
     Vec2 operator+(const Vec2& other) const { return {x + other.x, y + other.y}; }
+
+    /// @brief Component-wise subtraction.
     Vec2 operator-(const Vec2& other) const { return {x - other.x, y - other.y}; }
+
+    /// @brief Scalar multiplication.
     Vec2 operator*(float scalar) const { return {x * scalar, y * scalar}; }
 
+    /// @brief Compute the Euclidean length of the vector.
     float length() const { return std::sqrt(x * x + y * y); }
 
+    /**
+     * @brief Return a vector clamped to a maximum length.
+     * @param maxLength The maximum allowed length.
+     * @return A scaled-down copy if length exceeds maxLength, otherwise *this.
+     */
     Vec2 normalized(float maxLength) const {
         float len = length();
         if (len > maxLength && len > 0) {
@@ -30,6 +56,7 @@ struct Vec2 {
         return *this;
     }
 
+    /// @brief Check whether both components are exactly zero.
     bool isZero() const { return x == 0.0f && y == 0.0f; }
 };
 

--- a/include/core/Vec2.hpp
+++ b/include/core/Vec2.hpp
@@ -1,0 +1,36 @@
+#ifndef VEC2_HPP
+#define VEC2_HPP
+
+#include <cmath>
+#include <utility>
+
+struct Vec2 {
+    float x = 0.0f;
+    float y = 0.0f;
+
+    Vec2() = default;
+    Vec2(float x, float y) : x(x), y(y) {}
+
+    // Allow implicit conversion to/from std::pair for backward compatibility
+    Vec2(const std::pair<float, float>& p) : x(p.first), y(p.second) {}
+    operator std::pair<float, float>() const { return {x, y}; }
+
+    Vec2 operator+(const Vec2& other) const { return {x + other.x, y + other.y}; }
+    Vec2 operator-(const Vec2& other) const { return {x - other.x, y - other.y}; }
+    Vec2 operator*(float scalar) const { return {x * scalar, y * scalar}; }
+
+    float length() const { return std::sqrt(x * x + y * y); }
+
+    Vec2 normalized(float maxLength) const {
+        float len = length();
+        if (len > maxLength && len > 0) {
+            float scale = maxLength / len;
+            return {x * scale, y * scale};
+        }
+        return *this;
+    }
+
+    bool isZero() const { return x == 0.0f && y == 0.0f; }
+};
+
+#endif

--- a/src/core/Genes.cpp
+++ b/src/core/Genes.cpp
@@ -3,9 +3,7 @@
 #include <functional>
 #include <random>
 
-Genes::Genes(const char *dnaStr) : Genes(dnaStr, nullptr) {
-    std::memcpy(dna, dnaStr, 4);
-}
+Genes::Genes(const char *dnaStr) : Genes(dnaStr, nullptr) {}
 
 Genes::Genes(const char *dnaStr, MutationFunction customMutationLogic = nullptr)
     : mutationLogic(customMutationLogic ? customMutationLogic : defaultMutationLogic) {
@@ -26,8 +24,7 @@ void Genes::defaultMutationLogic(char dna[4]) {
     std::uniform_int_distribution<int> distribution(-3, 3);
 
     for (int i = 0; i < 4; ++i) {
-        int mutation = distribution(rng);
-        dna[i] += mutation;
+        dna[i] += distribution(rng);
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `Vec2` struct to replace `std::pair<float,float>` for positions/movement — improves readability (`pos.x` vs `pos.first`)
- Fix `EnvironmentObject`: make `position` protected, remove unnecessary `virtual` from `getPosition`/`setPosition`
- Fix double `memcpy` bug in `Genes` constructor
- Fix `calculateDistance` taking `shared_ptr` by value (unnecessary ref count bump)
- Make `Food::canBeEaten()` const, add `Food(int energy)` constructor for configurable energy
- Remove all commented-out `printf` debug statements (~20 lines)
- Use C++17 structured bindings in Environment iteration loops
- Pre-compute organism list before thread dispatch, skip thread creation for `numThreads=1`

## Discussion Points
- `Vec2` 提供了 `operator std::pair<float,float>()` 以維持向後相容。Python bindings 仍然回傳 tuple，不需要改動 Python 端程式碼
- `EnvironmentObject::position` 改為 `protected`，讓 `Organism` 可以直接存取而不需要透過 virtual dispatch
- `Food` 新增 `Food(int energy)` constructor，但預設仍然是 500，不會影響現有行為
- `SpatialIndexType` enum 已加入但 constructor 仍接受 string 以維持 Python API 相容性

## Test plan
- [x] All 3 existing Python tests pass
- [ ] Verify Python examples still work correctly
- [ ] Verify Food(energy) constructor works from Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)