### PR TITLE
feat: add injectable Python behavior strategies for Organism

### DIFF
--- a/bindings/core/Organism_bindings.cpp
+++ b/bindings/core/Organism_bindings.cpp
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
+#include <pybind11/stl.h>
 
 #include <core/Organism.hpp>
 
@@ -17,9 +18,16 @@ void init_Organism(py::module &m) {
         .def("killed", &Organism::killed)
         .def("is_alive", &Organism::isAlive)
         .def("can_reproduce", &Organism::canReproduce)
-        // .def("is_full", &Organism::isFull)
+        .def("add_life_span", &Organism::addLifeSpan, py::arg("amount"))
         .def("reproduce", &Organism::reproduce)
         .def("get_reaction_radius", &Organism::getReactionRadius)
         .def("interact", &Organism::interact)
-        .def("post_iteration", &Organism::postIteration);
+        .def("react", &Organism::react)
+        .def("post_iteration", &Organism::postIteration)
+        .def("set_reaction_strategy", &Organism::setReactionStrategy, py::arg("strategy"),
+             "Set a custom reaction strategy. The callable receives (organism, nearby_objects) "
+             "and should return a (dx, dy) tuple for movement direction, or (0, 0) for no reaction.")
+        .def("set_interaction_strategy", &Organism::setInteractionStrategy, py::arg("strategy"),
+             "Set a custom interaction strategy. The callable receives (organism, nearby_objects) "
+             "and should perform interactions (e.g., eat food, kill organisms).");
 }

--- a/examples/custom_behavior.py
+++ b/examples/custom_behavior.py
@@ -1,0 +1,146 @@
+"""
+Example: Custom Python Behavior Strategies
+
+Demonstrates how to define organism behavior entirely in Python
+without modifying the C++ engine. Two species coexist:
+- Herbivores: only eat food, flee from all organisms
+- Predators: ignore food, chase smaller organisms
+"""
+
+import random
+
+from simevopy import Environment, Food, Genes, Organism
+
+
+# --- Custom Reaction Strategies ---
+
+def herbivore_reaction(organism, nearby_objects):
+    """Herbivores prioritize food, flee from any organism."""
+    my_pos = organism.get_position()
+    nearest_food = None
+    nearest_food_dist = float("inf")
+    nearest_org = None
+    nearest_org_dist = float("inf")
+
+    for obj in nearby_objects:
+        dx = my_pos[0] - obj.get_position()[0]
+        dy = my_pos[1] - obj.get_position()[1]
+        dist = (dx * dx + dy * dy) ** 0.5
+
+        if hasattr(obj, "can_be_eaten") and obj.can_be_eaten():
+            if dist < nearest_food_dist:
+                nearest_food = obj
+                nearest_food_dist = dist
+        elif hasattr(obj, "is_alive") and obj.is_alive():
+            if dist < nearest_org_dist:
+                nearest_org = obj
+                nearest_org_dist = dist
+
+    # Flee from organisms if one is very close
+    if nearest_org and nearest_org_dist < 20:
+        org_pos = nearest_org.get_position()
+        return (my_pos[0] - org_pos[0], my_pos[1] - org_pos[1])
+
+    # Otherwise move toward food
+    if nearest_food:
+        food_pos = nearest_food.get_position()
+        return (food_pos[0] - my_pos[0], food_pos[1] - my_pos[1])
+
+    return (0.0, 0.0)
+
+
+def predator_reaction(organism, nearby_objects):
+    """Predators chase smaller organisms, ignore food."""
+    my_pos = organism.get_position()
+    my_size = organism.get_size()
+
+    nearest_prey = None
+    nearest_prey_dist = float("inf")
+
+    for obj in nearby_objects:
+        if not hasattr(obj, "is_alive") or not obj.is_alive():
+            continue
+        if not hasattr(obj, "get_size"):
+            continue
+        if obj.get_size() >= my_size:
+            continue
+
+        dx = my_pos[0] - obj.get_position()[0]
+        dy = my_pos[1] - obj.get_position()[1]
+        dist = (dx * dx + dy * dy) ** 0.5
+
+        if dist < nearest_prey_dist:
+            nearest_prey = obj
+            nearest_prey_dist = dist
+
+    if nearest_prey:
+        prey_pos = nearest_prey.get_position()
+        return (prey_pos[0] - my_pos[0], prey_pos[1] - my_pos[1])
+
+    return (0.0, 0.0)
+
+
+# --- Custom Interaction Strategies ---
+
+def herbivore_interaction(organism, nearby_objects):
+    """Herbivores only eat food, never attack other organisms."""
+    for obj in nearby_objects:
+        if hasattr(obj, "can_be_eaten") and obj.can_be_eaten():
+            organism.add_life_span(obj.get_energy())
+            obj.eaten()
+
+
+def predator_interaction(organism, nearby_objects):
+    """Predators eat smaller organisms, ignore food."""
+    for obj in nearby_objects:
+        if not hasattr(obj, "is_alive") or not obj.is_alive():
+            continue
+        if not hasattr(obj, "get_size"):
+            continue
+        if organism.get_size() > 1.2 * obj.get_size():
+            organism.add_life_span(obj.get_life_span())
+            obj.killed()
+
+
+def no_life_cost(organism):
+    """Zero life consumption for demo purposes."""
+    return 0
+
+
+def main():
+    env = Environment(500, 500)
+
+    # Create herbivores (small, fast, high awareness)
+    for _ in range(15):
+        dna = chr(60) + chr(15) + chr(80) + chr(0)  # fast, small, aware
+        org = Organism(Genes(dna), no_life_cost)
+        org.set_reaction_strategy(herbivore_reaction)
+        org.set_interaction_strategy(herbivore_interaction)
+        env.add_organism(org, random.uniform(10, 490), random.uniform(10, 490))
+
+    # Create predators (slower, bigger, less awareness)
+    for _ in range(5):
+        dna = chr(30) + chr(80) + chr(60) + chr(0)  # slow, big, moderate awareness
+        org = Organism(Genes(dna), no_life_cost)
+        org.set_reaction_strategy(predator_reaction)
+        org.set_interaction_strategy(predator_interaction)
+        env.add_organism(org, random.uniform(10, 490), random.uniform(10, 490))
+
+    # Add food
+    for _ in range(30):
+        env.add_food(Food(), random.uniform(10, 490), random.uniform(10, 490))
+
+    # Run simulation
+    env.simulate_iteration(200)
+
+    # Report results
+    alive = env.get_all_organisms()
+    print(f"\nAfter 200 iterations:")
+    print(f"  Surviving organisms: {len(alive)}")
+    print(f"  Remaining food: {len(env.get_all_foods())}")
+    print(f"  Food consumed: {env.get_food_consumption_in_iteration()}")
+    print(f"  Dead organisms: {len(env.get_dead_organisms())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `ReactionStrategy` and `InteractionStrategy` as injectable `std::function` types on `Organism`
- Python users can now fully customize how organisms behave without touching C++ code
- Strategies are inherited by offspring via `reproduce()`
- Default behavior unchanged when no custom strategy is set

## Usage Example (Python)
```python
from simevopy import Organism, Genes, Food

# Custom reaction: flee from everything
def flee_strategy(organism, nearby_objects):
    if not nearby_objects:
        return (0.0, 0.0)
    my_pos = organism.get_position()
    obj_pos = nearby_objects[0].get_position()
    return (my_pos[0] - obj_pos[0], my_pos[1] - obj_pos[1])

# Custom interaction: pacifist (only eat food, never kill)
def pacifist_strategy(organism, nearby_objects):
    for obj in nearby_objects:
        if hasattr(obj, 'can_be_eaten') and obj.can_be_eaten():
            organism.add_life_span(500)

org = Organism(Genes(chr(40) * 4))
org.set_reaction_strategy(flee_strategy)
org.set_interaction_strategy(pacifist_strategy)
```

## New Python API
| Method | Description |
|---|---|
| `organism.set_reaction_strategy(fn)` | Set custom reaction to nearby objects. `fn(organism, objects) -> (dx, dy)` |
| `organism.set_interaction_strategy(fn)` | Set custom interaction logic. `fn(organism, objects) -> None` |
| `organism.add_life_span(amount)` | Modify lifespan from custom strategies |

## Discussion Points
- `handleInteractions` 和 `handleReactions` 改為 single-threaded 以避免 Python callback 的 GIL deadlock。未來如果要恢復多線程，需要在 C++ 端做 GIL release/acquire 管理
- 目前 `nearby_objects` 包含所有 `EnvironmentObject`（Food + Organism），Python 端需要用 `hasattr` 或 `isinstance` 判斷類型。考慮是否要提供 typed accessor 來簡化
- Strategies 是 per-organism 的。如果想要 per-species 共用，可以在 Python 端用同一個 function reference

## Test plan
- [x] All 3 existing Python tests pass
- [x] Custom Python strategy smoke test passes
- [ ] Test strategy inheritance through reproduce()
- [ ] Test mixed default/custom organisms in same environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)