### PR TITLE
feat: support custom Python EnvironmentObject subclasses

### DIFF
--- a/bindings/core/EnvironmentObject_bindings.cpp
+++ b/bindings/core/EnvironmentObject_bindings.cpp
@@ -4,8 +4,18 @@
 
 namespace py = pybind11;
 
+// Trampoline class to allow Python subclassing of EnvironmentObject
+class PyEnvironmentObject : public EnvironmentObject {
+public:
+    using EnvironmentObject::EnvironmentObject;
+
+    void postIteration() override {
+        PYBIND11_OVERRIDE(void, EnvironmentObject, postIteration);
+    }
+};
+
 void init_EnvironmentObject(py::module &m) {
-    py::class_<EnvironmentObject, std::shared_ptr<EnvironmentObject>>(m, "EnvironmentObject")
+    py::class_<EnvironmentObject, PyEnvironmentObject, std::shared_ptr<EnvironmentObject>>(m, "EnvironmentObject")
         .def(py::init<float, float>())
         .def("get_position", &EnvironmentObject::getPosition)
         .def("get_id", &EnvironmentObject::getId)

--- a/bindings/core/Environment_bindings.cpp
+++ b/bindings/core/Environment_bindings.cpp
@@ -24,6 +24,11 @@ void init_Environment(py::module& m) {
              static_cast<void (Environment::*)(const std::shared_ptr<Food>&, float, float)>(
                  &Environment::add),
              py::arg("food"), py::arg("x"), py::arg("y"), "Add food at specified coordinates.")
+        .def("add_object",
+             static_cast<void (Environment::*)(const std::shared_ptr<EnvironmentObject>&, float, float)>(
+                 &Environment::add),
+             py::arg("object"), py::arg("x"), py::arg("y"),
+             "Add a custom EnvironmentObject at specified coordinates.")
         .def("remove_organism",
              static_cast<void (Environment::*)(const std::shared_ptr<Organism>&)>(
                  &Environment::remove),
@@ -31,6 +36,10 @@ void init_Environment(py::module& m) {
         .def("remove_food",
              static_cast<void (Environment::*)(const std::shared_ptr<Food>&)>(&Environment::remove),
              py::arg("food"), "Remove food from the environment.")
+        .def("remove_object",
+             static_cast<void (Environment::*)(const std::shared_ptr<EnvironmentObject>&)>(
+                 &Environment::remove),
+             py::arg("object"), "Remove a custom EnvironmentObject from the environment.")
         .def("reset", &Environment::reset, "Reset the environment.")
         .def("get_all_objects", &Environment::getAllObjects, "Get all objects in the environment.")
         .def("get_all_organisms", &Environment::getAllOrganisms,

--- a/include/core/Environment.hpp
+++ b/include/core/Environment.hpp
@@ -65,6 +65,15 @@ public:
     void add(const std::shared_ptr<Food>& food, float x, float y);
 
     /**
+     * @brief Add a generic EnvironmentObject (e.g. a Python subclass) at the specified coordinates.
+     * @param object Shared pointer to the environment object.
+     * @param x Horizontal position.
+     * @param y Vertical position.
+     * @throws std::out_of_range If (x, y) is outside the environment bounds.
+     */
+    void add(const std::shared_ptr<EnvironmentObject>& object, float x, float y);
+
+    /**
      * @brief Remove an organism from the environment and spatial index.
      * @param organism Shared pointer to the organism to remove.
      * @throws std::runtime_error If the organism is not found.
@@ -77,6 +86,13 @@ public:
      * @throws std::runtime_error If the food is not found.
      */
     void remove(const std::shared_ptr<Food>& food);
+
+    /**
+     * @brief Remove a generic EnvironmentObject from the environment and spatial index.
+     * @param object Shared pointer to the object to remove.
+     * @throws std::runtime_error If the object is not found.
+     */
+    void remove(const std::shared_ptr<EnvironmentObject>& object);
 
     /** @brief Clear all objects, dead organisms, and counters from the environment. */
     void reset();

--- a/src/core/Environment.cpp
+++ b/src/core/Environment.cpp
@@ -98,6 +98,34 @@ void Environment::remove(const std::shared_ptr<Food>& food) {
 }
 
 /**
+ * @brief Add a generic EnvironmentObject to the environment at the specified position.
+ * @param object Shared pointer to the environment object.
+ * @param x X coordinate.
+ * @param y Y coordinate.
+ * @throws std::out_of_range If coordinates are out of bounds.
+ */
+void Environment::add(const std::shared_ptr<EnvironmentObject>& object, float x, float y) {
+    checkBounds(x, y);
+    auto id = object->getId();
+    object->setPosition(x, y);
+    spatialIndex->insert(id, x, y);
+    objectsMapper.insert({id, object});
+}
+
+/**
+ * @brief Remove a generic EnvironmentObject from the environment.
+ * @param object Shared pointer to the object to remove.
+ * @throws std::runtime_error If the object is not found.
+ */
+void Environment::remove(const std::shared_ptr<EnvironmentObject>& object) {
+    if (objectsMapper.find(object->getId()) == objectsMapper.end()) {
+        throw std::runtime_error("Object not found in Environment.");
+    }
+    spatialIndex->remove(object->getId());
+    objectsMapper.erase(object->getId());
+}
+
+/**
  * @brief Reset the environment, removing all objects and clearing statistics.
  */
 void Environment::reset() {


### PR DESCRIPTION
## Summary
- Add pybind11 trampoline class to enable Python subclassing of `EnvironmentObject`
- Add generic `add_object`/`remove_object` methods to `Environment`
- Custom objects participate in the simulation loop via `postIteration()` override
- Custom objects are spatially indexed and appear in `get_all_objects()`

## Usage Example (Python)
```python
from simevopy import Environment, EnvironmentObject

class Obstacle(EnvironmentObject):
    def __init__(self):
        super().__init__(0, 0)
        self.damage = 10

    def post_iteration(self):
        pass  # obstacles don't move

class Trap(EnvironmentObject):
    def __init__(self):
        super().__init__(0, 0)
        self.triggered = False

    def post_iteration(self):
        pass

env = Environment(1000, 1000)
env.add_object(Obstacle(), 500, 500)
env.add_object(Trap(), 300, 300)
```

## Discussion Points
- Custom objects 會出現在 `get_all_objects()` 中，但不會出現在 `get_all_organisms()` 或 `get_all_foods()` 中
- 目前 custom objects 在 spatial index 中有位置，所以會被 organism 的 `react()`/`interact()` 看到。如果搭配 PR3 的 custom strategy，Python 端可以根據 object type 自定義互動行為
- `postIteration()` 會在每個 tick 被呼叫，可以用來實作會隨時間變化的地圖物件（如消失的牆壁、移動的障礙物）
- 如果 `postIteration()` 需要回呼 Python，目前的單線程 postIteration 迴圈是安全的

## Test plan
- [x] All 3 existing Python tests pass
- [x] Custom Python EnvironmentObject can be created, added, and removed
- [ ] Verify custom objects are visible in organism react/interact phase
- [ ] Test postIteration override from Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)