### PR TITLE
docs: add CLAUDE.md project guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md — SimEvo Project Guide
+
+## Project Overview
+
+SimEvo is a C++ simulation evolution engine with Python bindings (pybind11). The C++ engine handles the environment, spatial indexing, and simulation loop. Python users define organisms, behaviors, and interactions without modifying the C++ core.
+
+**Package name:** `simevopy` (published to PyPI)
+
+## Build & Run
+
+```bash
+# Build C++ library + Python bindings
+cmake -S . -B build -DBUILD_BINDINGS=ON
+cmake --build build
+
+# Build with C++ tests
+cmake -S . -B build -DBUILD_TESTS=ON -DBUILD_BINDINGS=OFF
+cmake --build build
+cd build && ctest -V
+
+# Install Python package (builds via CMake internally)
+pip install .
+
+# Run Python tests
+pytest
+
+# Run a single Python test
+pytest tests/python/test_chasing.py -v
+```
+
+**Dependencies:** CMake 3.24+, C++20 compiler, Boost (uuid), pybind11, Google Test (fetched automatically for C++ tests)
+
+## Project Structure
+
+```
+include/
+  core/           # Core simulation headers
+    Environment.hpp, EnvironmentObject.hpp, Food.hpp, Genes.hpp, Organism.hpp
+  index/          # Spatial index interface + implementations
+    ISpatialIndex.hpp, DefaultSpatialIndex.hpp, OptimizedSpatialIndex.hpp
+  utils/          # Utilities (profiler.hpp)
+src/
+  core/           # Core simulation implementation
+  index/          # Spatial index implementations
+bindings/
+  python_bindings.cpp          # Module entry point (PYBIND11_MODULE)
+  core/                        # Per-class pybind11 binding files
+    Environment_bindings.cpp, Organism_bindings.cpp, Food_bindings.cpp, etc.
+tests/
+  cpp/            # Google Test C++ tests
+  python/         # pytest Python tests
+examples/         # Python example scripts
+```
+
+## Architecture
+
+- **EnvironmentObject** — base class for everything placed in the environment (has UUID, position)
+- **Organism** — extends EnvironmentObject; has genes, lifespan, behavior strategies
+- **Food** — extends EnvironmentObject; can be eaten for energy
+- **Environment** — owns a spatial index, runs the simulation loop (reactions → interactions → cleanup)
+- **ISpatialIndex** — interface for spatial queries; `DefaultSpatialIndex` (brute-force) and `OptimizedSpatialIndex` (quadtree)
+
+Simulation loop per iteration: `updatePositionsInSpatialIndex()` → `handleReactions()` → `handleInteractions()` → `postIteration()` → `cleanUp()`
+
+## Coding Conventions
+
+- **C++20** standard required
+- **Clang-format**: Google style, 4-space indent, 100 column limit (see `.clang-format`)
+- **Doxygen comments**: Use `@brief`, `@param`, `@return` for all public API methods. Keep these even when refactoring — they will be used for documentation generation.
+- **Header guards**: `#ifndef CLASSNAME_HPP` / `#define` / `#endif`
+- **Smart pointers**: Use `std::shared_ptr` for objects stored in the environment
+- **Naming**: PascalCase for classes, camelCase for methods/variables in C++; snake_case for Python bindings
+
+## Python Bindings (pybind11)
+
+- Each C++ class has a corresponding `*_bindings.cpp` file in `bindings/core/`
+- Forward-declared in `bindings/python_bindings.cpp` and called via `init_ClassName(m)`
+- Python method names use snake_case (e.g., `get_position`, `add_organism`)
+- Use `py::arg(...)` for all parameters in bindings
+- Add docstrings to all bound methods
+- Exception registrations go in `python_bindings.cpp` (not duplicated in binding files)
+
+## Branching & PR Conventions
+
+- **Main branch:** `main`
+- **Branch naming:** `fix/description`, `feat/description`, `refactor/description`, `ci/description`
+- **PR titles:** concise, imperative mood
+- **Commit messages:** conventional commits style (`feat:`, `fix:`, `refactor:`, `ci:`, `chore:`)
+- CI runs on all PRs: C++ tests (ctest) + Python tests (pytest)
+- Version bumping and PyPI publishing happen automatically on merge to main
+
+## Testing
+
+- **C++ tests:** Google Test, located in `tests/cpp/`. Built when `-DBUILD_TESTS=ON`.
+- **Python tests:** pytest, located in `tests/python/`. Run after `pip install .`.
+- Always run both C++ and Python tests before opening a PR.
+
+## Key Gotchas
+
+- **Thread safety:** The interaction phase mutates shared state (organism lifespan, food state) and must run single-threaded. The reaction phase can be parallelized.
+- **GIL deadlock:** When Python callbacks (behavior strategies) are used, worker threads cannot acquire the GIL if the main thread holds it. Keep simulation single-threaded when Python callbacks are involved.
+- **pybind11 copyability:** Adding `std::atomic` or `std::mutex` to bound classes makes them non-copyable, which breaks pybind11's default return value policy. Avoid this.
+- **Spatial index:** Environment constructor accepts `type` param: `"default"` (brute-force) or `"optimized"` (quadtree).

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,175 @@
+# PROJECT.md — SimEvo Architecture & Design
+
+This document describes the technical architecture of SimEvo for developers and AI assistants working on the codebase.
+
+## Overview
+
+SimEvo is a C++20 simulation engine for natural selection with Python bindings via pybind11. The C++ core handles performance-critical simulation (spatial indexing, iteration loop, object lifecycle), while Python provides the user-facing API for defining organisms, behaviors, and running experiments.
+
+**Package:** `simevopy` (PyPI)
+**License:** MIT
+
+## System Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Python Layer                       │
+│   User scripts, custom behaviors, experiment setup    │
+├──────────────────────────────────────────────────────┤
+│                  pybind11 Bindings                     │
+│   bindings/core/*_bindings.cpp                        │
+│   snake_case API, py::arg(), docstrings               │
+├──────────────────────────────────────────────────────┤
+│                   C++ Engine                           │
+│   Environment → ISpatialIndex → Objects               │
+│   Simulation loop, thread management, profiling       │
+└──────────────────────────────────────────────────────┘
+```
+
+## Core Classes
+
+### EnvironmentObject (base class)
+- Every object in the simulation derives from this
+- Has a unique `boost::uuids::uuid` and a 2D position
+- Virtual `postIteration()` for per-tick lifecycle
+
+### Organism
+- Derives from EnvironmentObject
+- **Genes**: 4-byte DNA sequence; each byte maps to a trait (speed, size, awareness, reserved). Each byte 0-255 is divided by 4 to get the attribute value (0-64 range)
+- **Lifespan**: starts at 500, consumed each tick based on speed/size/awareness. Dies when <= 0
+- **Reproduction**: when lifespan > 1000, can create offspring with mutated genes. Parent's lifespan is halved
+- **Behavior strategies**: injectable `ReactionStrategy` and `InteractionStrategy` via `std::function`. Defaults to built-in C++ behavior if not set. Custom strategies (from Python or C++) are inherited by offspring
+
+### Food
+- Derives from EnvironmentObject
+- Has a FoodState (FRESH/EATEN) and an energy value (default 500)
+- Once eaten, marked EATEN and removed during cleanup
+
+### Environment
+- The simulation world: owns all objects via `unordered_map<uuid, shared_ptr<EnvironmentObject>>`
+- Spatial queries delegated to `ISpatialIndex<uuid>`
+- Constructor: `Environment(width, height, type="default"|"optimized", numThreads=1)`
+
+### ISpatialIndex
+- Interface for spatial queries (insert, remove, update, query-by-radius)
+- **DefaultSpatialIndex**: brute-force O(n) per query
+- **OptimizedSpatialIndex**: quadtree, better for large populations
+
+## Simulation Loop
+
+Each call to `simulateIteration(n)` runs `n` ticks. Each tick:
+
+```
+1. handleInteractions()
+   - For each alive organism, query spatial index by SIZE radius
+   - Call organism.interact() with nearby objects
+   - Eats food (gains energy), kills smaller organisms (absorbs lifespan)
+   - ⚠ Mutates shared state → must be single-threaded
+
+2. handleReactions()
+   - For each alive organism, query spatial index by REACTION radius (size + awareness)
+   - Call organism.react() with nearby objects
+   - Sets movement direction: flee from larger, chase smaller, approach food
+   - ✅ Only writes to own fields → can be parallelized (when no Python callbacks)
+
+3. postIteration()
+   - Each object's postIteration() is called
+   - Organisms: deduct life consumption, make movement, update position
+   - Positions clamped to environment bounds
+   - Spatial index positions updated
+
+4. cleanUp() (after all ticks)
+   - Remove dead organisms (store in deadOrganisms list)
+   - Remove eaten food (increment foodConsumption counter)
+```
+
+## Behavior Strategy System
+
+Organisms use a strategy pattern for customizable behavior:
+
+```
+ReactionStrategy = std::function<pair<float,float>(Organism&, vector<shared_ptr<EnvironmentObject>>)>
+InteractionStrategy = std::function<void(Organism&, vector<shared_ptr<EnvironmentObject>>)>
+```
+
+- If no custom strategy is set, `defaultReaction()` / `defaultInteraction()` are used
+- Custom strategies are set via `setReactionStrategy()` / `setInteractionStrategy()`
+- Strategies propagate to offspring during `reproduce()`
+- Python can define these as regular Python functions via pybind11
+
+## Genes & Mutation
+
+DNA is a 4-byte array. Default mutation adds a uniform random offset in [-3, +3] to each byte per generation. Custom mutation functions can be provided via `Genes::MutationFunction`.
+
+Trait mapping:
+| DNA Index | Trait      | Range (raw) | Range (scaled) |
+|-----------|------------|-------------|----------------|
+| 0         | Speed      | 0-255       | 0.0 - 63.75   |
+| 1         | Size       | 0-255       | 0.0 - 63.75   |
+| 2         | Awareness  | 0-255       | 0.0 - 63.75   |
+| 3         | Reserved   | 0-255       | —              |
+
+## Life Consumption Formula
+
+Default formula (can be overridden with `LifeConsumptionCalculator`):
+
+```
+consumption = (speed/10)^2 + (size/10)^2 * (size/15) + (awareness/10)) * 1.3
+```
+
+Larger, faster organisms burn energy disproportionately more.
+
+## Thread Safety Model
+
+| Phase            | Thread Safety | Reason |
+|------------------|---------------|--------|
+| handleInteractions | Single-threaded | Mutates food state, organism lifespans |
+| handleReactions    | Parallelizable* | Each organism only writes to its own movement |
+| postIteration      | Single-threaded | Updates shared spatial index |
+
+*When Python callbacks are set as strategies, reactions must also be single-threaded to avoid GIL deadlocks. The main thread holds the GIL; worker threads cannot acquire it.
+
+## File Structure
+
+```
+include/
+  core/
+    EnvironmentObject.hpp    # Base class (UUID + position)
+    Organism.hpp             # Living entity with genes and strategies
+    Food.hpp                 # Consumable energy source
+    Genes.hpp                # 4-byte DNA with mutation
+    Environment.hpp          # Simulation world and loop
+  index/
+    ISpatialIndex.hpp        # Spatial query interface
+    DefaultSpatialIndex.hpp  # Brute-force implementation
+    OptimizedSpatialIndex.hpp # Quadtree implementation
+  utils/
+    profiler.hpp             # Performance timing utility
+
+src/core/                    # Implementation files
+src/index/                   # Spatial index implementations
+
+bindings/
+  python_bindings.cpp        # PYBIND11_MODULE entry point
+  core/*_bindings.cpp        # Per-class binding definitions
+
+tests/
+  cpp/                       # Google Test C++ tests
+  python/                    # pytest Python tests
+
+examples/                    # Runnable Python example scripts
+```
+
+## Build System
+
+- **CMake 3.24+** with C++20 required
+- `BUILD_BINDINGS=ON` (default): builds pybind11 Python module
+- `BUILD_TESTS=ON`: builds Google Test C++ tests
+- `setup.py` wraps CMake for `pip install .`
+- CI: GitHub Actions runs both C++ and Python tests on every PR
+
+## Dependencies
+
+- **Boost** (uuid only): object identification
+- **pybind11**: Python bindings
+- **Google Test**: C++ tests (fetched automatically via CMake)


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project conventions, architecture overview, build instructions, and coding guidelines
- Documents key technical gotchas (thread safety, GIL deadlock, pybind11 copyability)
- Covers branching/PR conventions, testing workflow, and pybind11 binding patterns
- Emphasizes keeping Doxygen-style comments (`@brief`, `@param`, `@return`) for future docs generation

## Note
This file is used by Claude Code to understand the project context across sessions. It serves as a living reference for project conventions and architecture decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)